### PR TITLE
allow returning of associate array instead of object

### DIFF
--- a/src/GetResponseAPI3.class.php
+++ b/src/GetResponseAPI3.class.php
@@ -15,6 +15,7 @@ class GetResponse
     private $api_key;
     private $api_url = 'https://api.getresponse.com/v3';
     private $timeout = 8;
+    private $returnAssociative = false;
     public $http_status;
 
     /**
@@ -379,12 +380,13 @@ class GetResponse
         $curl = curl_init();
         curl_setopt_array($curl, $options);
 
-        $response = json_decode(curl_exec($curl));
+        $response = json_decode(curl_exec($curl), $this->returnAssociative);
 
         $this->http_status = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 
         curl_close($curl);
-        return (object)$response;
+
+        return $response;
     }
 
     /**


### PR DESCRIPTION
Things like $response->{'0'} seem clumsy compared to $response[0]
In my opinion arrays are easier to iterate over too.

Its more efficient to handle it by json_decode() directly then on the outside of the class.