### PR TITLE
Add contact search functionality to class

### DIFF
--- a/src/GetResponseAPI3.class.php
+++ b/src/GetResponseAPI3.class.php
@@ -162,6 +162,17 @@ class GetResponse
     {
         return $this->call('search-contacts?' . $this->setParams($params));
     }
+    
+    /**
+     * search for contacts without saving a search contact record
+     *
+     * @param $params
+     * @return mixed
+     */
+    public function contactSearch($params = array())
+    {   //print_r(json_decode(json_encode($this->call('search-contacts/contacts', 'POST', $params)), true));
+        return $this->call('search-contacts/contacts', 'POST', $params);
+    }
 
     /**
      * retrieve segment


### PR DESCRIPTION
Add this functionality to the class.

POST /search-contacts/contacts
This method allows to search contacts without saving the search. Request body contains a query, structured according to our reference and response is a collection of contacts meeting the criteria.